### PR TITLE
Update kustomization.yaml

### DIFF
--- a/kustom-webapp/overlays/dev/kustomization.yaml
+++ b/kustom-webapp/overlays/dev/kustomization.yaml
@@ -2,7 +2,7 @@ bases:
 - ../../base
 
 patches:
- - replicas.yaml
+- path: replicas.yaml
 
 configMapGenerator:
 - name: mykustom-map


### PR DESCRIPTION
The latest version of kustomize may be causing this error;

`error: invalid kustomization: json: cannot unmarshal string into go struct field kustomization.patches of type types.patch`